### PR TITLE
fix: fix null fields in getCardById and getSetByCode responses

### DIFF
--- a/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/networking/impl/MtgApiNetworkingImpl.kt
+++ b/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/networking/impl/MtgApiNetworkingImpl.kt
@@ -5,9 +5,11 @@ import com.rikezero.mtgapi_kotlin_sdk.networking.MtgApiNetworking
 import com.rikezero.mtgapi_kotlin_sdk.networking.networkadapter.MtgApiNetworkAdapter
 import com.rikezero.mtgapi_kotlin_sdk.networking.response.FormatsResponse
 import com.rikezero.mtgapi_kotlin_sdk.networking.response.MtgApiResponse
+import com.rikezero.mtgapi_kotlin_sdk.networking.response.card.CardSingleResponse
 import com.rikezero.mtgapi_kotlin_sdk.networking.response.lists.CardListResponse
 import com.rikezero.mtgapi_kotlin_sdk.networking.response.lists.CardSetListResponse
 import com.rikezero.mtgapi_kotlin_sdk.networking.response.set.CardSetResponse
+import com.rikezero.mtgapi_kotlin_sdk.networking.response.set.CardSetSingleResponse
 import com.rikezero.mtgapi_kotlin_sdk.networking.response.types.SubtypesResponse
 import com.rikezero.mtgapi_kotlin_sdk.networking.response.types.SuperTypesResponse
 import com.rikezero.mtgapi_kotlin_sdk.networking.response.types.TypesResponse
@@ -34,10 +36,14 @@ class MtgApiNetworkingImpl(
     }
 
     override suspend fun getCardById(id: String): MtgApiResponse<CardResponse?> {
-        return networkAdapter.get(
+        val response = networkAdapter.get(
             url = "${CARDS_ENDPOINT}/${id}",
-            responseClass = CardResponse::class
+            responseClass = CardSingleResponse::class
         )
+        return when (response) {
+            is MtgApiResponse.Success -> MtgApiResponse.Success(response.data?.card)
+            is MtgApiResponse.Error -> response
+        }
     }
 
     override suspend fun getSets(queries: HashMap<String, String>): MtgApiResponse<CardSetListResponse?> {
@@ -49,10 +55,14 @@ class MtgApiNetworkingImpl(
     }
 
     override suspend fun getSetByCode(code: String): MtgApiResponse<CardSetResponse?> {
-        return networkAdapter.get(
+        val response = networkAdapter.get(
             url = "${SETS_ENDPOINT}/${code}",
-            responseClass = CardSetResponse::class
+            responseClass = CardSetSingleResponse::class
         )
+        return when (response) {
+            is MtgApiResponse.Success -> MtgApiResponse.Success(response.data?.set)
+            is MtgApiResponse.Error -> response
+        }
     }
 
     override suspend fun getTypes(): MtgApiResponse<TypesResponse?> {

--- a/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/networking/response/card/CardSingleResponse.kt
+++ b/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/networking/response/card/CardSingleResponse.kt
@@ -1,0 +1,8 @@
+package com.rikezero.mtgapi_kotlin_sdk.networking.response.card
+
+import CardResponse
+import com.google.gson.annotations.SerializedName
+
+data class CardSingleResponse(
+    @SerializedName("card") val card: CardResponse?
+)

--- a/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/networking/response/set/CardSetSingleResponse.kt
+++ b/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/networking/response/set/CardSetSingleResponse.kt
@@ -1,0 +1,7 @@
+package com.rikezero.mtgapi_kotlin_sdk.networking.response.set
+
+import com.google.gson.annotations.SerializedName
+
+data class CardSetSingleResponse(
+    @SerializedName("set") val set: CardSetResponse?
+)


### PR DESCRIPTION
## Summary

- Add `CardSingleResponse` wrapper to correctly deserialize `GET /v1/cards/{id}` → `{"card": {...}}`
- Add `CardSetSingleResponse` wrapper to correctly deserialize `GET /v1/sets/{code}` → `{"set": {...}}`
- Update `MtgApiNetworkingImpl` to deserialize into wrapper then extract inner object

## Root Cause

`MtgApiNetworkEngineImpl.parseResponse()` called `gson.fromJson(body, CardResponse::class.java)` directly. The API wraps single-entity responses under a `"card"` / `"set"` key, so GSON mapped the root JSON object to `CardResponse` — none of the named fields matched and all came back null.

The list endpoints (`{"cards": [...]}`, `{"sets": [...]}`) already had correct wrapper classes (`CardListResponse`, `CardSetListResponse`) and worked fine.

## Files changed

| File | Action |
|------|--------|
| `networking/response/card/CardSingleResponse.kt` | New — wraps `CardResponse` under `"card"` key |
| `networking/response/set/CardSetSingleResponse.kt` | New — wraps `CardSetResponse` under `"set"` key |
| `networking/impl/MtgApiNetworkingImpl.kt` | Updated `getCardById` + `getSetByCode` to use wrappers |

## Test plan

- [ ] `./gradlew runCardByIdSample` — card fields (name, type, rarity, etc.) no longer null
- [ ] `./gradlew runCardSetByCodeSample` — set fields (code, name, releaseDate, etc.) no longer null
- [ ] `./gradlew runAllSamples` — all 8 samples complete successfully

Closes #81, Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)