### PR TITLE
docs(#24): README quick start, troubleshooting, API ref, version fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Overview
 
 This Kotlin SDK is built to interact with the [Magic: The Gathering API](https://magicthegathering.io), providing a clean,
-Kotlin-centric interface to access the API’s data. The SDK is designed to offer a more modern and structured approach with
+Kotlin-centric interface to access the API's data. The SDK is designed to offer a more modern and structured approach with
 features such as UseCases, tailored for better flexibility and ease of use compared to other SDKs available.
 
 The SDK was developed to offer a more modern alternative to the officially listed Kotlin SDK for the Magic: The Gathering API,
@@ -18,132 +18,167 @@ Feel free to use or fork it as per your needs!
 
 **WIP** - Ongoing updates to complete development and polish features.
 
+## API Reference
+
+Full generated API reference (KDoc): **[Releases → API Docs](https://github.com/rikezero/mtgapi-kotlin-sdk/releases)**
+
+> Once KDoc generation via Dokka is published (see [#32](https://github.com/rikezero/mtgapi-kotlin-sdk/issues/32)), this link will point to the hosted API reference.
+
 ## Version
 Current SDK version: v1.0.0.81
 
 ## Installation
 
-There are three methods you can choose from to install the MTG API Kotlin SDK into your project: via 
+There are three methods you can choose from to install the MTG API Kotlin SDK into your project: via
 GitHub Packages or Maven Central (recommended) or by manually downloading the `.jar` file.
 
-### Option 1: GitHub Packages (Recommended)
+### Option 1: GitHub Packages
 
-You can use GitHub Packages to easily install the SDK into your project using Gradle. Follow the instructions below:
+You can use GitHub Packages to install the SDK using Gradle. GitHub Packages requires authentication.
 
-1. Add the GitHub Packages repository to your `build.gradle` file:
+1. Add the GitHub Packages repository to your `build.gradle.kts` file:
 
-    ```gradle
+    ```kotlin
     repositories {
         maven {
             url = uri("https://maven.pkg.github.com/rikezero/mtgapi-kotlin-sdk")
             credentials {
-                username = project.findProperty("gpr.user") ?: System.getenv("USERNAME_GITHUB")
-                password = project.findProperty("gpr.token") ?: System.getenv("TOKEN_GITHUB")
+                username = project.findProperty("gpr.user") as String? ?: System.getenv("USERNAME_GITHUB")
+                password = project.findProperty("gpr.token") as String? ?: System.getenv("TOKEN_GITHUB")
             }
         }
     }
     ```
 
-3. Add the dependency for the SDK:
+2. Add the dependency:
 
-    ```gradle
+    ```kotlin
     dependencies {
-        implementation 'com.rikezero:mtgapi-kotlin-sdk:v1.0.0.71'
+        implementation("com.rikezero:mtgapi-kotlin-sdk:1.0.0.81")
     }
     ```
 
-   Make sure to replace `v1.0.0.71` with the appropriate version number as needed.
-
-3. To authenticate to GitHub Packages, create a personal access token on GitHub with the appropriate permissions 
-4. and set the `gpr.user` and `gpr.token` properties in your project (or environment variables).
-
-For more information about working with GitHub Packages, check out the 
-official [GitHub Packages documentation](https://docs.github.com/pt/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry).
+3. Authenticate by creating a [GitHub Personal Access Token](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry) with `read:packages` scope, then set `gpr.user` and `gpr.token` in your `~/.gradle/gradle.properties` (or as environment variables).
 
 ### Option 2: Maven Central (Recommended)
 
-You can use GitHub Packages to easily install the SDK into your project using Gradle. Follow the instructions below:
+No authentication required.
 
-1. Add the Maven Central repository to your `settings.gradle.kts` file:
+1. Ensure `mavenCentral()` is in your repositories (it is by default in most projects):
 
-   ```gradle
-   pluginManagement {
-      repositories {        
-        mavenCentral()        
-      }    
+   ```kotlin
+   // settings.gradle.kts
+   dependencyResolutionManagement {
+       repositories {
+           mavenCentral()
+       }
    }
    ```
 
-2. Add the dependency for the SDK to your `build.gradle.kts`:
+2. Add the dependency to your `build.gradle.kts`:
 
-   ```gradle
+   ```kotlin
    dependencies {
-      implementation("io.github.rikezero:mtgapi-kotlin-sdk:1.0.0.71")
+       implementation("io.github.rikezero:mtgapi-kotlin-sdk:1.0.0.81")
    }
    ```
-
-Make sure to replace `v1.0.0.71` with the appropriate version number as needed.
 
 ### Option 3: Manual Installation
 
-If you prefer not to use GitHub Packages, you can manually download the `.jar` file from the releases page of this repository.
+1. Visit the [Releases page](https://github.com/rikezero/mtgapi-kotlin-sdk/releases) and download the `.jar` file for the release you want.
+2. Place the `.jar` in your project's `libs/` directory.
+3. Add it as a dependency in your `build.gradle.kts`:
 
-1. Visit the [Releases page](https://github.com/rikezero/mtgapi-kotlin-sdk/releases) on GitHub.
-2. Download the `.jar` file corresponding to the release you want to use.
-3. Add the `.jar` file to your project's `libs` directory (or any folder where you store external dependencies).
-4. In your `build.gradle` file, add the following to include the `.jar` file in your project:
-
-    ```gradle
+    ```kotlin
     dependencies {
-        implementation files('libs/mtgapi-kotlin-sdk-v1.0.0.71.jar')
+        implementation(files("libs/mtgapi-kotlin-sdk-1.0.0.81.jar"))
     }
     ```
-
-Make sure to replace `mtgapi-kotlin-sdk-v1.0.0.71.jar` with the actual filename of the `.jar` file you downloaded.
 
 ## Initializing the Library in Koin
 
-Once you have successfully installed the library, you can initialize it in your Koin setup.
+Once installed, initialize the SDK's Koin modules **after** starting Koin and **before** using any SDK feature.
 
-1. **In your Application class (for Android)**:
+### Android
 
-    ```kotlin
-    class MyApplication : Application() {
-        override fun onCreate() {
-            super.onCreate()
+```kotlin
+class MyApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
 
-            // Initialize Koin when the app starts
-            startKoin {
-                androidContext(this@MyApplication)
-                modules(initialModules)  // This could be your global/default modules
-            }
-
-            // Load the MTG API library modules after Koin is initialized
-            startMtgApiLibrary()  // Ensure to call this after Koin initialization
-        }
-    }
-    ```
-
-2. **In a Pure Kotlin Project (non-Android)**:
-
-    ```kotlin
-    import org.koin.core.context.startKoin
-
-    fun main() {
-        // Initialize Koin with global/default modules
+        // 1. Start Koin with your own modules
         startKoin {
-            modules(initialModules)  // Define the modules you want to use globally and don't rely on this lib
+            androidContext(this@MyApplication)
+            modules(myAppModules)
         }
 
-        // Dynamically load the MTG API library modules
-        startMtgApiLibrary()  // Ensure to call this after Koin initialization
-        loadModulesThatRelyOnThisLib() //to prevent problems with dependency injection you should load your modules 
-        // after you've started MTG API Library
-    }
-    ```
+        // 2. Load SDK modules into the running Koin instance
+        startMtgApiLibrary()
 
-In both cases, ensure that `startMtgApiLibrary()` is called **after** initializing Koin (`startKoin()`), 
-but **before** using any services or features provided by the MTG API library.
+        // 3. Load your modules that depend on SDK types (e.g. inject GetCardsUseCase)
+        loadKoinModules(myModulesThatDependOnSdk)
+    }
+}
+```
+
+### Standalone JVM / Kotlin
+
+```kotlin
+import org.koin.core.context.startKoin
+
+fun main() {
+    // 1. Start Koin with your own modules
+    startKoin {
+        modules(myAppModules)
+    }
+
+    // 2. Load SDK modules into the running Koin instance
+    startMtgApiLibrary()
+
+    // 3. Load your modules that depend on SDK types
+    loadKoinModules(myModulesThatDependOnSdk)
+}
+```
+
+> **Order matters:** `startMtgApiLibrary()` must be called after `startKoin { }` but before injecting any SDK use case.
+
+## Quick Start
+
+After initialization, inject a use case and make your first API call:
+
+```kotlin
+import com.rikezero.mtgapi_kotlin_sdk.domain.usecase.GetCardsUseCase
+import com.rikezero.mtgapi_kotlin_sdk.domain.usecase.GetCardsUseCase.GetCardsParams
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+class CardRepository : KoinComponent {
+
+    private val getCards: GetCardsUseCase by inject()
+
+    suspend fun fetchDragons() {
+        val params = GetCardsParams(
+            name = "Dragon",
+            pageSize = 10
+        )
+
+        val result = getCards(params)
+
+        result
+            .onSuccess { cardList ->
+                println("Found ${cardList.cards.size} cards")
+                cardList.cards.forEach { println(it.name) }
+            }
+            .onFailure { error ->
+                println("Error: ${error.message}")
+            }
+    }
+}
+```
+
+> This example assumes the library is already initialized. See [Initializing the Library in Koin](#initializing-the-library-in-koin) above.
+
+All 8 use cases follow the same pattern — see [Integration Samples](#integration-samples) for runnable examples of every endpoint.
 
 ## Integration Samples
 
@@ -196,11 +231,9 @@ fun main() = runBlocking {
     val result = useCase(params)
 
     // 3. Handle result
-    if (result.isSuccess) {
-        println(result.getOrNull())
-    } else {
-        println("Error: ${result.exceptionOrNull()?.message}")
-    }
+    result
+        .onSuccess { println(it) }
+        .onFailure { println("Error: ${it.message}") }
 }
 ```
 
@@ -208,3 +241,51 @@ Sample files are located in:
 ```
 src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/samples/
 ```
+
+## Troubleshooting
+
+### `startMtgApiLibrary()` called before `startKoin()`
+
+**Symptom:** `KoinAppAlreadyStartedException` or `NoBeanDefFoundException` at startup before any API call is made.
+
+**Fix:** Ensure `startKoin { }` is called first, then `startMtgApiLibrary()`:
+
+```kotlin
+startKoin { modules(...) }   // ← must come first
+startMtgApiLibrary()          // ← then this
+```
+
+---
+
+### GitHub Packages authentication failure
+
+**Symptom:** Gradle sync fails with `401 Unauthorized` or `Could not resolve com.rikezero:mtgapi-kotlin-sdk`.
+
+**Fix:**
+1. Create a [GitHub Personal Access Token](https://github.com/settings/tokens) with the `read:packages` scope.
+2. Add credentials to `~/.gradle/gradle.properties`:
+
+   ```properties
+   gpr.user=YOUR_GITHUB_USERNAME
+   gpr.token=YOUR_PERSONAL_ACCESS_TOKEN
+   ```
+
+Alternatively, switch to **Maven Central** (Option 2) which requires no authentication.
+
+---
+
+### Transitive dependency version conflicts
+
+**Symptom:** Build fails with `Duplicate class` errors or `Could not resolve` for Koin, OkHttp, or Retrofit transitive dependencies.
+
+**Fix:** Force-resolve the conflicting version in your `build.gradle.kts`:
+
+```kotlin
+configurations.all {
+    resolutionStrategy {
+        force("io.insert-koin:koin-core:3.4.2")
+    }
+}
+```
+
+Check the [releases page](https://github.com/rikezero/mtgapi-kotlin-sdk/releases) for the dependency versions bundled with each SDK release.

--- a/context/kits/cavekit-readme.md
+++ b/context/kits/cavekit-readme.md
@@ -1,0 +1,97 @@
+---
+created: 2026-05-04T00:00:00Z
+last_edited: 2026-05-04T00:00:00Z
+---
+
+# Cavekit: Readme
+
+## Scope
+
+Defines the required content, structure, and correctness guarantees for the project's top-level README document. This kit covers what a consumer of the SDK must be able to learn from the README in order to install, initialize, perform a first successful API call, troubleshoot common setup mistakes, and locate generated reference documentation.
+
+This kit applies only to the README document itself. It does not govern source code, generated API reference content, sample applications, or release artifacts beyond what the README must say about them.
+
+## Requirements
+
+### R1: Installation Instructions
+**Description:** The README must describe three independent installation methods so a consumer can choose the one that fits their environment, and every version reference shown to the reader must reflect the current published version of the SDK.
+
+**Acceptance Criteria:**
+- [ ] An installation section exists and presents exactly three named installation methods.
+- [ ] One installation method covers obtaining the SDK from a hosted package registry that requires authentication.
+- [ ] One installation method covers obtaining the SDK from a public package registry that does not require authentication.
+- [ ] One installation method covers manual installation from a downloadable archive artifact.
+- [ ] Every concrete version identifier shown anywhere in the installation section equals the current published version `v1.0.0.81` (or its non-prefixed form `1.0.0.81` when the surrounding convention omits the `v`).
+- [ ] No installation method references a version other than the current one.
+- [ ] For the authenticated registry method, the reader is told that credentials are required and how those credentials are supplied to the build.
+- [ ] For the manual method, the reader is told where to obtain the artifact and how it is added as a dependency.
+
+**Dependencies:** None.
+
+### R2: Quick Start / Basic Usage
+**Description:** The README must contain a single, concise, end-to-end usage example that takes a reader from an initialized library to a handled API result, demonstrating dependency resolution, invoking a use case, and handling both the success and failure branches of the result type.
+
+**Acceptance Criteria:**
+- [ ] A section exists whose explicit purpose is showing first-call usage of the SDK (for example titled "Quick Start" or "Basic Usage").
+- [ ] The section contains exactly one primary code example demonstrating end-to-end usage.
+- [ ] The example shows obtaining a use case instance through dependency injection rather than by direct construction.
+- [ ] The example shows invoking the card list use case to fetch cards.
+- [ ] The example shows branching on the success state of the SDK's result type and accessing the success value.
+- [ ] The example shows branching on the failure state of the SDK's result type and accessing the failure cause.
+- [ ] The example is self-contained: every symbol referenced by the example is either defined within the example or imported from a clearly named package.
+- [ ] The example assumes the library has already been initialized and explicitly cross-references the initialization section rather than duplicating its content.
+
+**Dependencies:** R3 (initialization is a prerequisite of usage).
+
+### R3: Library Initialization
+**Description:** The README must explain how the library is initialized inside the consuming application's dependency injection container, covering both an Android application entry point and a non-Android JVM entry point, and must state the ordering constraints that make initialization correct.
+
+**Acceptance Criteria:**
+- [ ] A section exists dedicated to library initialization.
+- [ ] The section presents an example for an Android application entry point.
+- [ ] The section presents an example for a non-Android JVM entry point.
+- [ ] Each example shows the consumer initializing their own dependency injection container before initializing the SDK.
+- [ ] Each example shows the SDK initialization step as a single named call.
+- [ ] The section explicitly states that SDK initialization must occur after the consumer's dependency injection container is started.
+- [ ] The section explicitly states that SDK initialization must occur before any SDK feature is used.
+- [ ] The non-Android example shows or describes loading consumer modules that depend on the SDK after the SDK initialization call.
+
+**Dependencies:** R1 (installation is a prerequisite of initialization).
+
+### R4: Troubleshooting
+**Description:** The README must provide a troubleshooting section that diagnoses the most common setup failures a new consumer will encounter, so a reader hitting one of these failures can self-resolve without reading source code.
+
+**Acceptance Criteria:**
+- [ ] A section titled "Troubleshooting" (or equivalent) exists.
+- [ ] The section documents the symptom and resolution for initializing the SDK before the consumer's dependency injection container has been started.
+- [ ] The section documents the symptom and resolution for authentication failures when resolving the SDK from the authenticated package registry.
+- [ ] The section documents the symptom and resolution for transitive dependency version conflicts between the SDK and the consuming project.
+- [ ] Each documented issue states an observable symptom (for example, an error message or failure mode) and at least one corrective action.
+- [ ] No documented issue requires the reader to inspect SDK source code to apply the resolution.
+
+**Dependencies:** R3 (the ordering issue references the initialization contract defined there).
+
+### R5: API Reference Link
+**Description:** The README must direct readers to the published, generated API reference for the SDK, so consumers can look up types, parameters, and behaviors that are not covered by the narrative README content.
+
+**Acceptance Criteria:**
+- [ ] A section or clearly labeled link exists pointing the reader to the generated API reference documentation.
+- [ ] The link target is reachable over HTTP and returns a successful response.
+- [ ] The link is presented near the top-level navigation of the README (for example, in the overview, table of contents, or a dedicated documentation section) rather than buried inside an unrelated subsection.
+- [ ] The link text identifies the destination as API reference / generated documentation and is not a bare URL.
+
+**Dependencies:** None.
+
+## Out of Scope
+
+- Video tutorials, screencasts, or other non-text learning material.
+- Marketing copy, comparisons against competing libraries, or adoption pitches beyond the existing brief overview.
+- Architecture and internal design explanations (covered by a separate issue, #26).
+- Deep coverage of error taxonomy, retry policies, or failure recovery patterns (covered by a separate issue, #31).
+- Contribution guidelines, release process, or maintainer documentation.
+- Localization or translation of the README into languages other than English.
+- Per-endpoint usage walkthroughs beyond the single Quick Start example.
+
+## Cross-References
+
+- None. This kit is the only document-level kit currently planned. Future kits covering architecture documentation (#26) and error handling documentation (#31) should cross-reference R2 and R4 of this kit when they are drafted.


### PR DESCRIPTION
Closes #24

## Summary
- **Quick Start** section added — end-to-end `GetCardsUseCase` example using Koin injection, showing both `onSuccess` and `onFailure` branches
- **Troubleshooting** section added — covers three common issues: wrong `startMtgApiLibrary()` call order, GitHub Packages `401` auth failures, transitive dependency version conflicts
- **API Reference link** added near top of README (placeholder until Dokka/GitHub Pages is set up in #32)
- All version strings updated from `v1.0.0.71` → `v1.0.0.81`
- Gradle snippets converted from Groovy syntax to Kotlin DSL (`build.gradle.kts`)
- `context/kits/cavekit-readme.md` added (SDD spec backing this change)

## Test plan
- [ ] Render README on GitHub and verify all sections display correctly
- [ ] Verify all internal anchor links (`#initializing-the-library-in-koin`, `#integration-samples`) resolve
- [ ] Verify Quick Start code compiles against actual SDK types (`GetCardsUseCase`, `GetCardsParams`, `onSuccess`/`onFailure` extension fns)
- [ ] Verify no version reference remains at `v1.0.0.71`

🤖 Generated with [Claude Code](https://claude.com/claude-code)