### PR TITLE
docs(#26): architecture overview — layers, Mermaid diagrams, DI, extension points

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Full generated API reference (KDoc): **[Releases → API Docs](https://github.co
 
 > Once KDoc generation via Dokka is published (see [#32](https://github.com/rikezero/mtgapi-kotlin-sdk/issues/32)), this link will point to the hosted API reference.
 
+## Architecture
+
+Internal layer design, data flow diagrams, extension points, and the guide for adding new endpoints: **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)**
+
 ## Version
 Current SDK version: v1.0.0.81
 

--- a/context/kits/cavekit-architecture.md
+++ b/context/kits/cavekit-architecture.md
@@ -1,0 +1,96 @@
+---
+created: 2026-05-04T00:00:00Z
+last_edited: 2026-05-04T00:00:00Z
+---
+
+# Cavekit: Architecture
+
+## Scope
+Defines the contents of a new architecture document (`docs/ARCHITECTURE.md`) for the `mtgapi-kotlin-sdk` project, addressing issue #26. Covers what the document must explain about layering, data flow, dependency injection composition, extension points, and the procedure for adding a new endpoint. Does not prescribe prose style, formatting choices, or diagram tooling.
+
+## Requirements
+
+### R1: Directory Structure
+**Description:** The architecture document must present the package tree under `com.rikezero.mtgapi_kotlin_sdk/`, annotating each top-level package with its role. All five top-level packages must appear: `di/`, `domain/`, `networking/`, `util/`, `samples/`.
+**Acceptance Criteria:**
+- [ ] Document contains a section that renders the package tree rooted at `com.rikezero.mtgapi_kotlin_sdk/`.
+- [ ] Each of the packages `di/`, `domain/`, `networking/`, `util/`, `samples/` is present in that tree.
+- [ ] Each of those five packages has an inline annotation or adjacent description naming its role.
+- [ ] No top-level package under `com.rikezero.mtgapi_kotlin_sdk/` that exists in the codebase is omitted from the tree.
+**Dependencies:** None
+
+### R2: Layer Responsibilities
+**Description:** The document must define five architectural layers and assign explicit responsibilities to each, with a visual diagram showing their relationships.
+**Acceptance Criteria:**
+- [ ] A `networking/` layer is described as responsible for HTTP execution, the Retrofit service interface, response DTOs, and deserialization.
+- [ ] A `networking/networkadapter/` + `networking/engine/` layer is described as an abstraction over the raw HTTP client that enables engine swaps.
+- [ ] A `domain/repository/` layer is described as the contract isolating networking from domain, and explicitly names `MtgApiRepository` (interface) and `MtgApiRepositoryImpl`.
+- [ ] A `domain/usecase/` layer is described as the consumer entry point, states each use case wraps one repository method, and names the base class `MtgApiUseCase<P, T>`.
+- [ ] A `di/` layer is described as Koin module composition with three sub-modules wired via `startMtgApiLibrary()`.
+- [ ] A Mermaid `flowchart` diagram is present showing the five layers and their directional dependencies (consumer → UseCase → Repository → Networking → Engine → HTTP).
+**Dependencies:** R1
+
+### R3: Data Flow
+**Description:** The document must walk through the end-to-end sequence from a consumer's call to the returned result, rendered as a Mermaid sequence diagram.
+**Acceptance Criteria:**
+- [ ] A Mermaid `sequenceDiagram` block is present covering the full request/response cycle.
+- [ ] The sequence shows a consumer invoking a UseCase with params.
+- [ ] The sequence shows the Repository delegating to networking.
+- [ ] The sequence shows the NetworkAdapter passing through to the NetworkEngine.
+- [ ] The sequence shows a Retrofit HTTP call and ResponseBody deserialization.
+- [ ] The sequence shows `MtgApiResponse` being converted to `MtgApiResult` via `ResponseExtensions`.
+- [ ] The sequence shows a Mapper converting a Response DTO to a Domain Model.
+- [ ] The sequence shows the final `MtgApiResult` being returned to the caller.
+- [ ] The seven steps above appear in the order listed within the diagram.
+**Dependencies:** R2
+
+### R4: Koin DI Structure
+**Description:** The document must describe how Koin modules are composed and exposed.
+**Acceptance Criteria:**
+- [ ] Three Koin modules are named: `mtgApiNetworkingModules`, `mtgApiRepositoryModules`, `mtgApiUseCaseModules`.
+- [ ] The document states these are composed into a `mtgApiLibraryModules` list.
+- [ ] The document identifies `startMtgApiLibrary()` as the single entry point and notes it calls `loadKoinModules()`.
+- [ ] The document states the dependency chain: UseCase -> Repository -> Networking -> Adapter -> Engine -> Retrofit.
+**Dependencies:** R2
+
+### R5: Extension Points
+**Description:** The document must enumerate four extension points available to consumers.
+**Acceptance Criteria:**
+- [ ] Extension point 1 is documented: OkHttp interceptor list passed via `buildMtgApiRetrofit(interceptors=...)`, with stated use cases of logging, auth, and caching.
+- [ ] Extension point 2 is documented: per-request `JsonDeserializer<T>` override on `MtgApiNetworkAdapter.get(deserializer=...)`.
+- [ ] Extension point 3 is documented: providing a custom `MtgApiRepository` implementation to swap the data source without changing use cases.
+- [ ] Extension point 4 is documented: subclassing `MtgApiUseCase<P, T>` to add business logic on top of any repository method.
+**Dependencies:** R2, R4
+
+### R6: Adding a New Endpoint
+**Description:** The document must include a numbered, ordered, ten-step checklist for adding a new endpoint, with each step naming the layer and the specific file or directory affected.
+**Acceptance Criteria:**
+- [ ] Step 1 specifies creating a Response DTO under `networking/response/`.
+- [ ] Step 2 specifies creating a Domain Model under `domain/model/`.
+- [ ] Step 3 specifies adding a mapper function in `domain/mappers/MtgApiMappers.kt`.
+- [ ] Step 4 specifies adding a method to the repository interface in `domain/repository/MtgApiRepository.kt`.
+- [ ] Step 5 specifies updating the repository implementation in `domain/repository/impl/MtgApiRepositoryImpl.kt`.
+- [ ] Step 6 specifies adding a method to the networking interface in `networking/MtgApiNetworking.kt`.
+- [ ] Step 7 specifies updating the networking implementation in `networking/impl/MtgApiNetworkingImpl.kt`.
+- [ ] Step 8 specifies adding a Retrofit service method in `networking/service/MtgApiService.kt`.
+- [ ] Step 9 specifies adding a UseCase class under `domain/usecase/`.
+- [ ] Step 10 specifies registering bindings in `di/MtgApiModule.kt`.
+- [ ] The ten steps appear in the order listed above.
+**Dependencies:** R1, R2, R4
+
+### R7: README Linkage
+**Description:** The new architecture document must be discoverable from the project README.
+**Acceptance Criteria:**
+- [ ] `README.md` contains a link whose target resolves to `docs/ARCHITECTURE.md`.
+- [ ] The architecture document exists at the path `docs/ARCHITECTURE.md`.
+**Dependencies:** R1
+
+## Out of Scope
+- README structure or content beyond the single link to the architecture document (covered by issue #24 / cavekit-readme).
+- In-depth treatment of error handling semantics beyond naming `MtgApiResult` in the data flow (covered by issue #31).
+- KDoc generation, formatting, or publishing pipeline (covered by issue #32).
+- A consumer-facing Koin integration guide; only the SDK's internal Koin composition is in scope (covered by issue #28).
+- Internal implementation details that are not required to understand or extend the documented architecture.
+
+## Cross-References
+- See also: cavekit-readme.md (R24 overlap on the README link target)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,243 @@
+# Architecture Overview
+
+This document describes the internal structure of the MTG API Kotlin SDK — how the layers are organized, how data flows from an API call to a domain result, how Koin modules are composed, and how to extend or add to the SDK.
+
+**Audience:** SDK contributors and advanced users.
+
+---
+
+## Table of Contents
+
+1. [Directory Structure](#directory-structure)
+2. [Layer Responsibilities](#layer-responsibilities)
+3. [Data Flow](#data-flow)
+4. [Koin DI Structure](#koin-di-structure)
+5. [Extension Points](#extension-points)
+6. [Adding a New Endpoint](#adding-a-new-endpoint)
+
+---
+
+## Directory Structure
+
+```
+com.rikezero.mtgapi_kotlin_sdk/
+│
+├── di/                         # Koin module composition & library entry point
+│
+├── domain/                     # Business logic — models, use cases, repository contract
+│   ├── failure/                # MtgApiFailure sealed class hierarchy
+│   ├── mappers/                # Response DTO → Domain model conversions
+│   ├── model/                  # Domain entities (CardModel, CardSetModel, etc.)
+│   ├── repository/             # MtgApiRepository interface + MtgApiRepositoryImpl
+│   ├── result/                 # MtgApiResult<T> success/failure wrapper
+│   └── usecase/                # Public use case classes + MtgApiUseCase<P,T> base
+│
+├── networking/                 # HTTP layer — Retrofit service, DTOs, deserialization
+│   ├── deserializer/           # Gson configuration singleton (MtgApiDeserializer)
+│   ├── engine/                 # MtgApiNetworkEngine interface + Retrofit/OkHttp impl
+│   ├── impl/                   # MtgApiNetworkingImpl — maps endpoints to service calls
+│   ├── networkadapter/         # MtgApiNetworkAdapter interface + passthrough impl
+│   ├── response/               # Network response DTOs (CardResponse, MtgApiResponse, etc.)
+│   └── service/                # MtgApiService — Retrofit @GET interface
+│
+├── samples/                    # Standalone runnable samples for every endpoint
+│
+└── util/
+    └── response/               # ResponseExtensions — MtgApiResponse → MtgApiResult
+```
+
+---
+
+## Layer Responsibilities
+
+```mermaid
+flowchart TD
+    Consumer["Consumer\n(Android / JVM app)"]
+    UseCase["domain/usecase\nMtgApiUseCase&lt;P,T&gt;"]
+    Repository["domain/repository\nMtgApiRepository"]
+    Networking["networking/impl\nMtgApiNetworking"]
+    Adapter["networking/networkadapter\nMtgApiNetworkAdapter"]
+    Engine["networking/engine\nMtgApiNetworkEngine"]
+    HTTP["networking/service\nMtgApiService (Retrofit)"]
+
+    Consumer -->|"inject & call useCase(params)"| UseCase
+    UseCase -->|"repository.getX()"| Repository
+    Repository -->|"networking.getX()"| Networking
+    Networking -->|"adapter.get(url, ...)"| Adapter
+    Adapter -->|"engine.get(url, ...)"| Engine
+    Engine -->|"service.get(url, headers, queryParams)"| HTTP
+    HTTP -->|"ResponseBody"| Engine
+    Engine -->|"MtgApiResponse&lt;DTO&gt;"| Adapter
+    Adapter -->|"MtgApiResponse&lt;DTO&gt;"| Networking
+    Networking -->|"MtgApiResponse&lt;DTO&gt;"| Repository
+    Repository -->|"map DTO → Model\nMtgApiResult&lt;Model&gt;"| UseCase
+    UseCase -->|"MtgApiResult&lt;T&gt;"| Consumer
+```
+
+| Layer | Package | Responsibility |
+|---|---|---|
+| **UseCase** | `domain/usecase/` | Consumer entry point. Each use case wraps exactly one repository method. Extend `MtgApiUseCase<P, T>` and override `execute(params)`. |
+| **Repository** | `domain/repository/` | Contract isolating networking from domain. `MtgApiRepository` defines the interface; `MtgApiRepositoryImpl` calls networking and applies mappers. |
+| **Networking** | `networking/impl/` | Maps named SDK operations to HTTP calls via `MtgApiNetworkAdapter`. Owns endpoint URL constants. |
+| **Network Adapter / Engine** | `networking/networkadapter/` + `networking/engine/` | Abstraction over the raw HTTP client. `MtgApiNetworkAdapter` is the boundary; `MtgApiNetworkEngine` holds the Retrofit instance. Swapping the engine does not affect any layer above the adapter. |
+| **DI** | `di/` | Koin module composition. Three private sub-modules wired together and exposed via `startMtgApiLibrary()`. |
+
+---
+
+## Data Flow
+
+The sequence below uses `GetCardsUseCase` as the example. All other use cases follow the same path.
+
+```mermaid
+sequenceDiagram
+    participant Consumer
+    participant UseCase as GetCardsUseCase
+    participant Repository as MtgApiRepositoryImpl
+    participant Networking as MtgApiNetworkingImpl
+    participant Adapter as MtgApiNetworkAdapterImpl
+    participant Engine as MtgApiNetworkEngineImpl
+    participant Retrofit as MtgApiService (Retrofit)
+
+    Consumer->>UseCase: invoke(GetCardsParams(...))
+    UseCase->>Repository: getCards(params.toHashMap())
+    Repository->>Networking: getCards(queryParams)
+    Networking->>Adapter: get(url=CARDS_ENDPOINT, queryParams, responseClass=CardListResponse)
+    Adapter->>Engine: get(url, headers, queryParams, responseClass)
+    Engine->>Retrofit: service.get(url, headers, queryParams)
+    Retrofit-->>Engine: ResponseBody (raw JSON)
+    Engine-->>Engine: parseResponse(body, responseClass)\nGson deserialize → CardListResponse
+    Engine-->>Adapter: MtgApiResponse.Success(CardListResponse)
+    Adapter-->>Networking: MtgApiResponse.Success(CardListResponse)
+    Networking-->>Repository: MtgApiResponse.Success(CardListResponse)
+    Repository-->>Repository: response.toResult()\n(ResponseExtensions: MtgApiResponse → MtgApiResult)
+    Repository-->>Repository: cardListResponse.toModel()\n(MtgApiMappers: DTO → CardListModel)
+    Repository-->>UseCase: MtgApiResult.success(CardListModel)
+    UseCase-->>Consumer: MtgApiResult<CardListModel>
+```
+
+**Key conversion points:**
+
+- `ResponseExtensions.toResult()` — converts `MtgApiResponse<T>` to `MtgApiResult<T>`, wrapping errors as `MtgApiFailure`
+- `MtgApiMappers` — pure functions mapping each response DTO to its domain model (e.g., `CardListResponse.toModel()`)
+
+---
+
+## Koin DI Structure
+
+`startMtgApiLibrary()` is the single public entry point. It calls `loadKoinModules()` with three private modules:
+
+```
+mtgApiLibraryModules = [
+    mtgApiNetworkingModules,     // Retrofit, OkHttp, Engine, Adapter, Networking
+    mtgApiRepositoryModules,     // MtgApiRepository → MtgApiRepositoryImpl
+    mtgApiUseCaseModules         // All 8 use cases
+]
+```
+
+**Dependency chain (Koin resolution order):**
+
+```
+GetCardsUseCase
+  └─ MtgApiRepository (→ MtgApiRepositoryImpl)
+       └─ MtgApiNetworking (→ MtgApiNetworkingImpl)
+            └─ MtgApiNetworkAdapter (→ MtgApiNetworkAdapterImpl)
+                 └─ MtgApiNetworkEngine (→ MtgApiNetworkEngineImpl)
+                      └─ Retrofit (named "retrofit_mtgapi")
+```
+
+**Initialization contract:**
+
+1. Call `startKoin { }` with your own modules first.
+2. Call `startMtgApiLibrary()` — loads SDK modules into the running Koin instance.
+3. Load your own modules that inject SDK use cases (e.g., `GetCardsUseCase`).
+
+---
+
+## Extension Points
+
+### 1. OkHttp Interceptors
+
+Add logging, authentication, or caching interceptors by passing them to `buildMtgApiRetrofit()` inside a custom `MtgApiNetworkEngine` binding:
+
+```kotlin
+single<MtgApiNetworkEngine> {
+    MtgApiNetworkEngineImpl(
+        retrofit = buildMtgApiRetrofit(
+            host = BuildConfig.MAGIC_THE_GATHERING_BASE_URL,
+            interceptors = listOf(
+                HttpLoggingInterceptor().apply { level = HttpLoggingInterceptor.Level.BODY },
+                MyAuthInterceptor()
+            )
+        )
+    )
+}
+```
+
+Register this binding after `startMtgApiLibrary()` to override the default engine.
+
+### 2. Per-Request Custom Deserializer
+
+`MtgApiNetworkAdapter.get()` accepts an optional `JsonDeserializer<T>` that overrides the default Gson config for a single call:
+
+```kotlin
+adapter.get(
+    url = "v1/cards",
+    responseClass = CardListResponse::class,
+    deserializer = MyCardListDeserializer()
+)
+```
+
+Useful when the API returns a non-standard envelope for a specific endpoint.
+
+### 3. Custom Repository Implementation
+
+Implement `MtgApiRepository` directly to swap the data source (e.g., add caching, stub for tests) without changing any use case:
+
+```kotlin
+class CachingMtgApiRepository(
+    private val remote: MtgApiRepositoryImpl,
+    private val cache: CardCache
+) : MtgApiRepository {
+    override suspend fun getCards(params: HashMap<String, String>) =
+        cache.get(params) ?: remote.getCards(params).also { cache.put(params, it) }
+    // ...
+}
+```
+
+Bind it in Koin before loading your dependent modules.
+
+### 4. Custom Use Case
+
+Extend `MtgApiUseCase<P, T>` to add business logic on top of any repository call:
+
+```kotlin
+class GetDragonCardsUseCase(
+    private val repository: MtgApiRepository
+) : MtgApiUseCase<Unit, CardListModel>() {
+    override suspend fun execute(params: Unit) =
+        repository.getCards(hashMapOf("name" to "Dragon", "pageSize" to "20"))
+}
+```
+
+Register it in your own Koin module — no changes to the SDK required.
+
+---
+
+## Adding a New Endpoint
+
+Follow these steps in order. Each step names the layer and the file to create or edit.
+
+| Step | Action | File |
+|------|--------|------|
+| 1 | **Create Response DTO** — mirror the API JSON structure | `networking/response/{domain}/{Name}Response.kt` (new) |
+| 2 | **Create Domain Model** — clean entity, no JSON annotations | `domain/model/{domain}/{Name}Model.kt` (new) |
+| 3 | **Add mapper function** — `{Name}Response.toModel()` | `domain/mappers/MtgApiMappers.kt` (edit) |
+| 4 | **Add repository interface method** | `domain/repository/MtgApiRepository.kt` (edit) |
+| 5 | **Implement repository method** — call networking, apply mapper | `domain/repository/impl/MtgApiRepositoryImpl.kt` (edit) |
+| 6 | **Add networking interface method** | `networking/MtgApiNetworking.kt` (edit) |
+| 7 | **Implement networking method** — add endpoint constant, call adapter | `networking/impl/MtgApiNetworkingImpl.kt` (edit) |
+| 8 | **Add Retrofit service method** — `@GET` annotated suspend fun | `networking/service/MtgApiService.kt` (edit) |
+| 9 | **Create UseCase** — extend `MtgApiUseCase<P, T>`, delegate to repository | `domain/usecase/Get{Name}UseCase.kt` (new) |
+| 10 | **Register in Koin** — `single<Get{Name}UseCase> { Get{Name}UseCase(get()) }` | `di/MtgApiModule.kt` (edit) |
+
+**Files touched per new endpoint:** 3 new, 7 edits.


### PR DESCRIPTION
Closes #26

## Summary
- New `docs/ARCHITECTURE.md` covering the full internal structure of the SDK
- Mermaid `flowchart` diagram — 7-layer dependency graph (Consumer → UseCase → Repository → Networking → Adapter → Engine → Retrofit)
- Mermaid `sequenceDiagram` — complete `GetCardsUseCase` request/response cycle including DTO deserialization, `ResponseExtensions` conversion, and mapper
- Annotated package tree for all 5 top-level packages
- Layer responsibilities table
- Koin module composition and dependency chain
- 4 documented extension points (OkHttp interceptors, per-request deserializer, custom repository, custom use case)
- 10-step ordered checklist for adding a new endpoint (3 new files, 7 edits)
- `README.md`: Architecture section added linking to `docs/ARCHITECTURE.md`
- `context/kits/cavekit-architecture.md`: SDD spec backing this change

## Test plan
- [ ] Verify Mermaid diagrams render correctly on GitHub (flowchart + sequenceDiagram)
- [ ] Verify all 10 endpoint-addition steps reference real file paths that exist in the repo
- [ ] Verify README Architecture link resolves to `docs/ARCHITECTURE.md`
- [ ] Verify package tree matches actual directory structure under `src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)