### PR TITLE
docs(#32): KDoc for all public API — use cases, models, result types, DI

### DIFF
--- a/context/kits/cavekit-kdoc.md
+++ b/context/kits/cavekit-kdoc.md
@@ -1,0 +1,47 @@
+---
+created: 2026-05-04T00:00:00Z
+last_edited: 2026-05-04T00:00:00Z
+---
+
+# Cavekit: KDoc Generation
+
+## Scope
+KDoc comments on all public API classes, methods, and properties.
+
+## Requirements
+
+### R1: Use Cases
+**Acceptance Criteria:**
+- [ ] All 8 use case classes have class-level KDoc
+- [ ] Each use case's invoke/execute method has KDoc with @return
+- [ ] GetCardsUseCase.GetCardsParams documents all query parameters with @param
+
+### R2: Repository
+**Acceptance Criteria:**
+- [ ] MtgApiRepository interface has class-level KDoc
+- [ ] All repository methods have @param and @return
+
+### R3: Domain Models
+**Acceptance Criteria:**
+- [ ] All 10 domain model classes have class-level KDoc
+- [ ] Non-obvious properties documented with @property
+
+### R4: Result / Failure
+**Acceptance Criteria:**
+- [ ] MtgApiResult class/typealias has KDoc
+- [ ] All extension functions (onSuccess, onFailure, map, mapToNotNull) have KDoc
+- [ ] MtgApiFailure sealed class and all subtypes have KDoc stating when each occurs
+
+### R5: Networking Interfaces
+**Acceptance Criteria:**
+- [ ] MtgApiNetworking, MtgApiNetworkAdapter, MtgApiNetworkEngine have class-level KDoc
+- [ ] All interface methods have @param and @return
+
+### R6: DI Entry Point
+**Acceptance Criteria:**
+- [ ] startMtgApiLibrary() has KDoc covering calling-order contract
+
+## Out of Scope
+- Dokka build configuration
+- GitHub Pages publishing
+- Internal implementation files (private classes)

--- a/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/failure/MtgApiFailure.kt
+++ b/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/failure/MtgApiFailure.kt
@@ -1,5 +1,15 @@
 package com.rikezero.mtgapi_kotlin_sdk.domain.failure
 
+/**
+ * Sealed hierarchy of all structured failure types produced by the MTG API SDK.
+ *
+ * Every error that propagates through [com.rikezero.mtgapi_kotlin_sdk.domain.result.MtgApiResult]
+ * is an instance of this class. Callers can exhaustively handle failures by switching on the
+ * concrete subtype using `when`.
+ *
+ * @param message An optional human-readable description of the error.
+ * @param cause The underlying exception that triggered this failure, if any.
+ */
 sealed class MtgApiFailure(
     message: String?,
     cause: Throwable?
@@ -12,8 +22,29 @@ sealed class MtgApiFailure(
     override val message: String?
         get() = super.message ?: GENERIC_ERROR
 
+    /**
+     * Produced when an error occurs that does not fit any other known failure category.
+     *
+     * Common scenarios include a `null` payload being returned where a non-null value was
+     * required (e.g., via [com.rikezero.mtgapi_kotlin_sdk.domain.result.mapToNotNull]) or
+     * an unexpected exception thrown during data mapping.
+     *
+     * @param cause The underlying exception.
+     * @param message An optional human-readable description of the failure.
+     */
     class UnknownFailure(cause: Throwable, message: String? = null) : MtgApiFailure(message, cause)
 
+    /**
+     * Produced when the network request to the MTG API fails or the server returns an error response.
+     *
+     * This failure carries a structured [Error] object with an API-specific error [Error.code]
+     * and [Error.message], along with the optional HTTP status code.
+     *
+     * @property error The structured API error returned by the server.
+     * @property httpCode The HTTP status code of the failed response (e.g., 404, 500), if available.
+     * @param message An optional human-readable description of the failure.
+     * @param cause The underlying exception, if any.
+     */
     class NetworkingFailure(
         val error: Error,
         val httpCode: Int? = null,
@@ -21,6 +52,12 @@ sealed class MtgApiFailure(
         cause: Throwable? = null
     ): MtgApiFailure(message, cause) {
 
+        /**
+         * Structured error detail returned by the MTG API server.
+         *
+         * @property code A machine-readable error code string identifying the error type.
+         * @property message A human-readable description of the error.
+         */
         class Error(
             val code: String,
             val message: String

--- a/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/model/FormatsModel.kt
+++ b/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/model/FormatsModel.kt
@@ -2,6 +2,14 @@ package com.rikezero.mtgapi_kotlin_sdk.domain.model
 
 import kotlinx.serialization.Serializable
 
+/**
+ * Domain model containing all supported Magic: The Gathering game formats.
+ *
+ * Game formats define the rules and card pool used in competitive and casual play.
+ * Examples include Standard, Modern, Legacy, Vintage, Commander, and Pioneer.
+ *
+ * @property formats The list of format names supported by the MTG API.
+ */
 @Serializable
 data class FormatsModel(
     val formats: List<String>

--- a/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/model/card/CardModel.kt
+++ b/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/model/card/CardModel.kt
@@ -2,6 +2,41 @@ package com.rikezero.mtgapi_kotlin_sdk.domain.model.card
 
 import kotlinx.serialization.Serializable
 
+/**
+ * Domain model representing a single Magic: The Gathering card.
+ *
+ * This is the canonical card representation exposed to callers of the SDK.
+ * All properties are nullable because not every card in the MTG API response includes
+ * every field (e.g., only creatures have [power] and [toughness]; only planeswalkers have [loyalty]).
+ *
+ * @property name The card name.
+ * @property manaCost The mana cost of the card expressed in MTG mana symbols (e.g., "{2}{W}{U}").
+ * @property cmc The converted mana cost, always a number.
+ * @property colors The colors of the card, usually derived from the casting cost.
+ * @property colorIdentity The color identity of the card, by color code (e.g., ["R", "U"]).
+ * @property type The full type line of the card as printed (e.g., "Legendary Creature — Human Warrior").
+ * @property types The card's types (e.g., Creature, Instant, Sorcery).
+ * @property superTypes The card's supertypes (e.g., Basic, Legendary, Snow).
+ * @property subTypes The card's subtypes (e.g., Human, Elf, Equipment).
+ * @property rarity The rarity of the card (e.g., Common, Uncommon, Rare, Mythic Rare).
+ * @property set The set code of the set the card belongs to.
+ * @property setName The full name of the set the card belongs to.
+ * @property text The Oracle text of the card, which may contain mana symbols.
+ * @property flavor The flavor text printed on the card.
+ * @property artist The artist credit for the card illustration.
+ * @property number The collector number printed on the card; may contain letters (e.g., "123a").
+ * @property power The power value for creature cards; may be a non-numeric string (e.g., "1+*").
+ * @property toughness The toughness value for creature cards; may be a non-numeric string.
+ * @property layout The card layout (e.g., normal, split, flip, double-faced, token).
+ * @property multiverseId The Multiverse ID of the card on Wizards' Gatherer website, if available.
+ * @property imageUrl The URL of the card image.
+ * @property rulings The official rulings associated with this card.
+ * @property foreignNames The card's name and Multiverse ID in other languages.
+ * @property printings The set codes of all sets in which this card has been printed.
+ * @property originalText The original Oracle text of the card at the time of printing.
+ * @property originalType The original type line of the card at the time of printing.
+ * @property id The unique identifier for this card, generated as an SHA1 hash of set code + card name + card image name.
+ */
 @Serializable
 data class CardModel(
     val name: String?,

--- a/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/model/card/ForeignNameModel.kt
+++ b/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/model/card/ForeignNameModel.kt
@@ -2,6 +2,16 @@ package com.rikezero.mtgapi_kotlin_sdk.domain.model.card
 
 import kotlinx.serialization.Serializable
 
+/**
+ * Domain model representing a card's name and identifier in a non-English language.
+ *
+ * Foreign name entries are included in [CardModel.foreignNames] for cards that have been
+ * printed in languages other than English.
+ *
+ * @property name The card name in the given [language].
+ * @property language The language in which the card was printed (e.g., "German", "Japanese").
+ * @property multiverseid The Multiverse ID of this foreign printing on Wizards' Gatherer website.
+ */
 @Serializable
 data class ForeignNameModel(
     val name: String?,

--- a/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/model/card/RulingModel.kt
+++ b/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/model/card/RulingModel.kt
@@ -2,6 +2,15 @@ package com.rikezero.mtgapi_kotlin_sdk.domain.model.card
 
 import kotlinx.serialization.Serializable
 
+/**
+ * Domain model representing an official ruling for a Magic: The Gathering card.
+ *
+ * Rulings are official clarifications issued by Wizards of the Coast regarding how a card
+ * should be played. They are included in [CardModel.rulings].
+ *
+ * @property date The date the ruling was issued, formatted as "YYYY-MM-DD".
+ * @property text The text of the ruling describing the official clarification.
+ */
 @Serializable
 data class RulingModel(
     val date: String?,

--- a/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/model/lists/CardListModel.kt
+++ b/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/model/lists/CardListModel.kt
@@ -3,6 +3,14 @@ package com.rikezero.mtgapi_kotlin_sdk.domain.model.lists
 import com.rikezero.mtgapi_kotlin_sdk.domain.model.card.CardModel
 import kotlinx.serialization.Serializable
 
+/**
+ * Domain model representing a paginated list of Magic: The Gathering cards.
+ *
+ * Returned by [com.rikezero.mtgapi_kotlin_sdk.domain.usecase.GetCardsUseCase] and the
+ * underlying repository when querying multiple cards at once.
+ *
+ * @property cards The list of [CardModel] objects returned by the query.
+ */
 @Serializable
 data class CardListModel(
     val cards: List<CardModel>

--- a/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/model/lists/CardSetListModel.kt
+++ b/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/model/lists/CardSetListModel.kt
@@ -3,6 +3,14 @@ package com.rikezero.mtgapi_kotlin_sdk.domain.model.lists
 import com.rikezero.mtgapi_kotlin_sdk.domain.model.set.CardSetModel
 import kotlinx.serialization.Serializable
 
+/**
+ * Domain model representing a list of Magic: The Gathering sets.
+ *
+ * Returned by [com.rikezero.mtgapi_kotlin_sdk.domain.usecase.GetSetsUseCase] and the
+ * underlying repository when querying multiple sets at once.
+ *
+ * @property sets The list of [CardSetModel] objects returned by the query.
+ */
 @Serializable
 data class CardSetListModel(
     val sets: List<CardSetModel>

--- a/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/model/set/CardSetModel.kt
+++ b/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/model/set/CardSetModel.kt
@@ -3,6 +3,20 @@ package com.rikezero.mtgapi_kotlin_sdk.domain.model.set
 import com.rikezero.mtgapi_kotlin_sdk.domain.model.card.CardModel
 import kotlinx.serialization.Serializable
 
+/**
+ * Domain model representing a Magic: The Gathering set (expansion).
+ *
+ * A set groups a collection of cards released together. This model surfaces the most
+ * commonly needed set metadata returned by the MTG API.
+ *
+ * @property code The short set code (e.g., "KTK" for Khans of Tarkir).
+ * @property name The full name of the set (e.g., "Khans of Tarkir").
+ * @property type The set type (e.g., "expansion", "core", "masters", "promo").
+ * @property booster The booster pack composition for the set as a list of card representations.
+ * @property releaseDate The official release date of the set, formatted as "YYYY-MM-DD".
+ * @property block The block name that this set belongs to, if applicable.
+ * @property onlineOnly Whether the set is available exclusively on Magic Online and not in paper.
+ */
 @Serializable
 data class CardSetModel(
     val code: String?,

--- a/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/model/types/TypesModel.kt
+++ b/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/model/types/TypesModel.kt
@@ -2,16 +2,37 @@ package com.rikezero.mtgapi_kotlin_sdk.domain.model.types
 
 import kotlinx.serialization.Serializable
 
+/**
+ * Domain model containing all card types available in Magic: The Gathering.
+ *
+ * Card types appear on the left of the dash in a card's type line (e.g., Creature, Instant, Sorcery).
+ *
+ * @property types The list of all card type names.
+ */
 @Serializable
 data class TypesModel(
     val types: List<String>
 )
 
+/**
+ * Domain model containing all card subtypes available in Magic: The Gathering.
+ *
+ * Subtypes appear on the right of the dash in a card's type line (e.g., Human, Elf, Equipment, Aura).
+ *
+ * @property subTypes The list of all card subtype names.
+ */
 @Serializable
 data class SubtypesModel(
     val subTypes: List<String>
 )
 
+/**
+ * Domain model containing all card supertypes available in Magic: The Gathering.
+ *
+ * Supertypes appear to the far left of the card type line (e.g., Basic, Legendary, Snow, World).
+ *
+ * @property superTypes The list of all card supertype names.
+ */
 @Serializable
 data class SuperTypesModel(
     val superTypes: List<String>

--- a/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/repository/MtgApiRepository.kt
+++ b/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/repository/MtgApiRepository.kt
@@ -11,21 +11,72 @@ import com.rikezero.mtgapi_kotlin_sdk.domain.model.types.TypesModel
 import com.rikezero.mtgapi_kotlin_sdk.domain.result.MtgApiResult
 import com.rikezero.mtgapi_kotlin_sdk.networking.response.MtgApiResponse
 
+/**
+ * Contract for all data operations performed against the MTG API.
+ *
+ * Implementations are responsible for fetching raw network responses, mapping them to domain
+ * models, and returning the result wrapped in [MtgApiResult]. Callers should not interact
+ * with the network layer directly — always go through this interface.
+ */
 interface MtgApiRepository {
 
+    /**
+     * Fetches a paginated, filtered list of cards.
+     *
+     * @param queries Key-value map of query parameters (e.g., name, set, rarity).
+     * @return [MtgApiResult] wrapping a [CardListModel] on success, or a failure on error.
+     */
     suspend fun getCards(queries: HashMap<String, String>): MtgApiResult<CardListModel>
 
+    /**
+     * Fetches a single card by its unique identifier.
+     *
+     * @param id The card's SHA1-based MTG API ID or Multiverse ID.
+     * @return [MtgApiResult] wrapping a [CardModel] on success, or a failure on error.
+     */
     suspend fun getCardById(id: String): MtgApiResult<CardModel>
 
+    /**
+     * Fetches a filtered list of Magic: The Gathering sets.
+     *
+     * @param queries Key-value map of query parameters (e.g., name, block).
+     * @return [MtgApiResult] wrapping a [CardSetListModel] on success, or a failure on error.
+     */
     suspend fun getSets(queries: HashMap<String, String>): MtgApiResult<CardSetListModel>
 
+    /**
+     * Fetches a single set by its set code.
+     *
+     * @param code The set code (e.g., "KTK" for Khans of Tarkir).
+     * @return [MtgApiResult] wrapping a [CardSetModel] on success, or a failure on error.
+     */
     suspend fun getSetByCode(code: String): MtgApiResult<CardSetModel>
 
+    /**
+     * Fetches all available card types (e.g., Creature, Instant, Sorcery).
+     *
+     * @return [MtgApiResult] wrapping a [TypesModel] on success, or a failure on error.
+     */
     suspend fun getTypes(): MtgApiResult<TypesModel>
 
+    /**
+     * Fetches all available card subtypes (e.g., Human, Elf, Equipment).
+     *
+     * @return [MtgApiResult] wrapping a [SubtypesModel] on success, or a failure on error.
+     */
     suspend fun getSubtypes(): MtgApiResult<SubtypesModel>
 
+    /**
+     * Fetches all available card supertypes (e.g., Basic, Legendary, Snow).
+     *
+     * @return [MtgApiResult] wrapping a [SuperTypesModel] on success, or a failure on error.
+     */
     suspend fun getSupertypes(): MtgApiResult<SuperTypesModel>
 
+    /**
+     * Fetches all supported game formats (e.g., Standard, Legacy, Commander).
+     *
+     * @return [MtgApiResult] wrapping a [FormatsModel] on success, or a failure on error.
+     */
     suspend fun getFormats(): MtgApiResult<FormatsModel>
 }

--- a/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/repository/impl/MtgApiRepositoryImpl.kt
+++ b/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/repository/impl/MtgApiRepositoryImpl.kt
@@ -15,6 +15,13 @@ import com.rikezero.mtgapi_kotlin_sdk.domain.result.mapToNotNull
 import com.rikezero.mtgapi_kotlin_sdk.networking.MtgApiNetworking
 import com.rikezero.mtgapi_kotlin_sdk.util.response.result
 
+/**
+ * Default implementation of [MtgApiRepository].
+ *
+ * Fetches data through [MtgApiNetworking], maps each network response to its corresponding
+ * domain model via extension functions, and wraps the result in [MtgApiResult].
+ * Null network payloads are converted to [com.rikezero.mtgapi_kotlin_sdk.domain.failure.MtgApiFailure.UnknownFailure].
+ */
 class MtgApiRepositoryImpl(
     private val mtgApiNetworking: MtgApiNetworking
 ): MtgApiRepository {

--- a/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/result/MtgApiResult.kt
+++ b/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/result/MtgApiResult.kt
@@ -2,30 +2,72 @@ package com.rikezero.mtgapi_kotlin_sdk.domain.result
 
 import com.rikezero.mtgapi_kotlin_sdk.domain.failure.MtgApiFailure
 
+/**
+ * A discriminated result container used throughout the MTG API SDK.
+ *
+ * An instance either holds a successful value of type [R] or a [Throwable] representing failure.
+ * Use [isSuccess] / [isFailure] to branch, [getOrNull] to extract the value, and [exceptionOrNull]
+ * to extract the cause. The extension functions [onSuccess], [onFailure], [map], and [mapToNotNull]
+ * provide a fluent API for chaining result handling.
+ *
+ * Create instances via the companion object factory methods:
+ * - [MtgApiResult.success] — wraps a successful value.
+ * - [MtgApiResult.failure] — wraps a [Throwable] as a failure.
+ *
+ * @param R The type of the success value.
+ */
 open class MtgApiResult<out R> @PublishedApi internal constructor(
     @PublishedApi
     internal val value: Any? = null
 ){
+    /** `true` when this result holds a successful value. */
     val isSuccess: Boolean = value !is Throwable
+
+    /** `true` when this result holds a failure [Throwable]. */
     val isFailure: Boolean = value is Throwable
 
+    /**
+     * Returns the encapsulated success value, or `null` if this is a failure.
+     */
     @Suppress("UNCHECKED_CAST")
     fun getOrNull(): R? = when {
         isFailure -> null
         else -> value as R
     }
 
+    /**
+     * Returns the encapsulated [Throwable] if this is a failure, or `null` on success.
+     */
     fun exceptionOrNull(): Throwable? = when {
         isFailure -> value as Throwable?
         else -> null
     }
 
     companion object{
+        /**
+         * Creates a successful [MtgApiResult] wrapping [value].
+         *
+         * @param value The successful result value.
+         */
         fun <T> success(value: T): MtgApiResult<T> = MtgApiResult(value)
+
+        /**
+         * Creates a failed [MtgApiResult] wrapping [throwable].
+         *
+         * @param throwable The exception describing why the operation failed.
+         */
         fun <T> failure(throwable: Throwable): MtgApiResult<T> = MtgApiResult(throwable)
     }
 }
 
+/**
+ * Transforms the success value of this result using [transform], leaving failure results unchanged.
+ *
+ * @param T The type of the original success value.
+ * @param R The type of the transformed success value.
+ * @param transform A function applied to the success value to produce a new value of type [R].
+ * @return A new [MtgApiResult] containing the transformed value on success, or the original failure.
+ */
 @Suppress("UNCHECKED_CAST")
 inline fun <T, R> MtgApiResult<T>.map(
     transform: (value: T) -> R
@@ -34,12 +76,33 @@ inline fun <T, R> MtgApiResult<T>.map(
     else -> MtgApiResult.failure(value as Throwable)
 }
 
+/**
+ * Transforms the nullable success value of this result using [transform], treating a `null` value
+ * as a failure.
+ *
+ * If the success value is `null`, a [MtgApiFailure.UnknownFailure] wrapping a [NullPointerException]
+ * is produced. Use this when a non-null result is required by the domain layer.
+ *
+ * @param T The type of the original (nullable) success value.
+ * @param R The type of the transformed success value.
+ * @param transform A function applied to the non-null success value.
+ * @return A new [MtgApiResult] containing the transformed non-null value, or a failure.
+ */
 inline fun <T, R> MtgApiResult<T?>.mapToNotNull(
     transform: (value: T) -> R
 ): MtgApiResult<R> = this.map {
     it?.let(transform) ?: throw MtgApiFailure.UnknownFailure(NullPointerException())
 }
 
+/**
+ * Runs [block] with the success value if this result is a success, then returns this result unchanged.
+ *
+ * Useful for side-effects such as logging or updating UI state without breaking a chain.
+ *
+ * @param T The type of the success value.
+ * @param block A side-effect block invoked with the success value.
+ * @return This [MtgApiResult] unchanged.
+ */
 @Suppress("UNCHECKED_CAST")
 inline fun <T> MtgApiResult<T>.onSuccess(
     block: (T) -> Unit
@@ -52,6 +115,15 @@ inline fun <T> MtgApiResult<T>.onSuccess(
     }
 }
 
+/**
+ * Runs [block] with the encapsulated [Throwable] if this result is a failure, then returns this result unchanged.
+ *
+ * Useful for side-effects such as error logging or reporting without breaking a chain.
+ *
+ * @param T The type of the success value.
+ * @param block A side-effect block invoked with the failure [Throwable].
+ * @return This [MtgApiResult] unchanged.
+ */
 inline fun <T> MtgApiResult<T>.onFailure(
     block: (Throwable) -> Unit
 ): MtgApiResult<T> {

--- a/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/usecase/GetCardByIdUseCase.kt
+++ b/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/usecase/GetCardByIdUseCase.kt
@@ -6,14 +6,21 @@ import com.rikezero.mtgapi_kotlin_sdk.domain.result.MtgApiResult
 import com.rikezero.mtgapi_kotlin_sdk.domain.usecase.base.MtgApiUseCase
 
 /**
- * UseCase for searching a specific card.
+ * Use case for retrieving a single Magic: The Gathering card by its unique identifier.
  *
- * @property params Searches for a specific card by id or multiverseid
- *
- **/
+ * Delegates to [MtgApiRepository.getCardById] with the provided card ID.
+ * The ID may be either the MTG API's own SHA1-based card ID or a Multiverse ID.
+ */
 class GetCardByIdUseCase(
     private val mtgApiRepository: MtgApiRepository
 ): MtgApiUseCase<String, CardModel>() {
+
+    /**
+     * Executes the use case by fetching a single card matching the given ID.
+     *
+     * @param params The card ID (SHA1-based MTG API ID or Multiverse ID) to look up.
+     * @return [MtgApiResult] wrapping a [CardModel] on success, or a failure on error.
+     */
     override suspend fun execute(params: String): MtgApiResult<CardModel> {
         return mtgApiRepository.getCardById(params)
     }

--- a/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/usecase/GetCardsUseCase.kt
+++ b/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/usecase/GetCardsUseCase.kt
@@ -6,6 +6,12 @@ import com.rikezero.mtgapi_kotlin_sdk.domain.result.MtgApiResult
 import com.rikezero.mtgapi_kotlin_sdk.domain.usecase.GetCardsUseCase.GetCardsParams
 import com.rikezero.mtgapi_kotlin_sdk.domain.usecase.base.MtgApiUseCase
 
+/**
+ * Use case for retrieving a list of Magic: The Gathering cards.
+ *
+ * Delegates to [MtgApiRepository.getCards] using the query parameters provided
+ * via [GetCardsParams]. Results are returned as [MtgApiResult] wrapping a [CardListModel].
+ */
 class  GetCardsUseCase(
     private val mtgApiRepository: MtgApiRepository
 ): MtgApiUseCase<GetCardsParams, CardListModel>() {
@@ -98,6 +104,12 @@ class  GetCardsUseCase(
         }
     }
 
+    /**
+     * Executes the use case by fetching a filtered list of cards from the repository.
+     *
+     * @param params The filtering and pagination parameters for the card query.
+     * @return [MtgApiResult] wrapping a [CardListModel] on success, or a failure on error.
+     */
     override suspend fun execute(params: GetCardsParams): MtgApiResult<CardListModel> {
         return mtgApiRepository.getCards(params.toHashMap())
     }

--- a/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/usecase/GetFormatsUseCase.kt
+++ b/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/usecase/GetFormatsUseCase.kt
@@ -5,9 +5,21 @@ import com.rikezero.mtgapi_kotlin_sdk.domain.repository.MtgApiRepository
 import com.rikezero.mtgapi_kotlin_sdk.domain.result.MtgApiResult
 import com.rikezero.mtgapi_kotlin_sdk.domain.usecase.base.MtgApiUseCase
 
+/**
+ * Use case for retrieving all supported Magic: The Gathering game formats (e.g., Standard, Legacy, Commander).
+ *
+ * Delegates to [MtgApiRepository.getFormats]. No input parameters are required.
+ */
 class GetFormatsUseCase(
     private val mtgApiRepository: MtgApiRepository
 ): MtgApiUseCase<Unit, FormatsModel>() {
+
+    /**
+     * Executes the use case by fetching all available game formats.
+     *
+     * @param params Unused — pass [Unit].
+     * @return [MtgApiResult] wrapping a [FormatsModel] on success, or a failure on error.
+     */
     override suspend fun execute(params: Unit): MtgApiResult<FormatsModel> {
         return mtgApiRepository.getFormats()
     }

--- a/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/usecase/GetSetByIdUseCase.kt
+++ b/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/usecase/GetSetByIdUseCase.kt
@@ -5,9 +5,21 @@ import com.rikezero.mtgapi_kotlin_sdk.domain.repository.MtgApiRepository
 import com.rikezero.mtgapi_kotlin_sdk.domain.result.MtgApiResult
 import com.rikezero.mtgapi_kotlin_sdk.domain.usecase.base.MtgApiUseCase
 
+/**
+ * Use case for retrieving a single Magic: The Gathering set by its set code.
+ *
+ * Delegates to [MtgApiRepository.getSetByCode] with the provided set code string.
+ */
 class GetSetByIdUseCase(
     private val mtgApiRepository: MtgApiRepository
 ): MtgApiUseCase<String,CardSetModel>() {
+
+    /**
+     * Executes the use case by fetching the set matching the given set code.
+     *
+     * @param params The set code (e.g., "KTK" for Khans of Tarkir) to look up.
+     * @return [MtgApiResult] wrapping a [CardSetModel] on success, or a failure on error.
+     */
     override suspend fun execute(params: String): MtgApiResult<CardSetModel> {
         return mtgApiRepository.getSetByCode(params)
     }

--- a/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/usecase/GetSetsUseCase.kt
+++ b/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/usecase/GetSetsUseCase.kt
@@ -6,6 +6,12 @@ import com.rikezero.mtgapi_kotlin_sdk.domain.result.MtgApiResult
 import com.rikezero.mtgapi_kotlin_sdk.domain.usecase.GetSetsUseCase.SetParameters
 import com.rikezero.mtgapi_kotlin_sdk.domain.usecase.base.MtgApiUseCase
 
+/**
+ * Use case for retrieving a list of Magic: The Gathering sets.
+ *
+ * Delegates to [MtgApiRepository.getSets] using the query parameters provided
+ * via [SetParameters]. Results are returned as [MtgApiResult] wrapping a [CardSetListModel].
+ */
 class GetSetsUseCase(
     private val mtgApiRepository: MtgApiRepository
 ): MtgApiUseCase<SetParameters, CardSetListModel>() {
@@ -42,6 +48,12 @@ class GetSetsUseCase(
         }
     }
 
+    /**
+     * Executes the use case by fetching a filtered list of sets from the repository.
+     *
+     * @param params The filtering parameters (name and/or block) for the set query.
+     * @return [MtgApiResult] wrapping a [CardSetListModel] on success, or a failure on error.
+     */
     override suspend fun execute(params: SetParameters): MtgApiResult<CardSetListModel> {
         return mtgApiRepository.getSets(params.toHashMap())
     }

--- a/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/usecase/GetSubTypesUseCase.kt
+++ b/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/usecase/GetSubTypesUseCase.kt
@@ -5,9 +5,21 @@ import com.rikezero.mtgapi_kotlin_sdk.domain.repository.MtgApiRepository
 import com.rikezero.mtgapi_kotlin_sdk.domain.result.MtgApiResult
 import com.rikezero.mtgapi_kotlin_sdk.domain.usecase.base.MtgApiUseCase
 
+/**
+ * Use case for retrieving all Magic: The Gathering card subtypes (e.g., Human, Elf, Equipment).
+ *
+ * Delegates to [MtgApiRepository.getSubtypes]. No input parameters are required.
+ */
 class GetSubTypesUseCase(
     private val mtgApiRepository: MtgApiRepository
 ): MtgApiUseCase<Unit, SubtypesModel>() {
+
+    /**
+     * Executes the use case by fetching all available card subtypes.
+     *
+     * @param params Unused — pass [Unit].
+     * @return [MtgApiResult] wrapping a [SubtypesModel] on success, or a failure on error.
+     */
     override suspend fun execute(params: Unit): MtgApiResult<SubtypesModel> {
         return mtgApiRepository.getSubtypes()
     }

--- a/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/usecase/GetSuperTypesUseCase.kt
+++ b/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/usecase/GetSuperTypesUseCase.kt
@@ -5,9 +5,21 @@ import com.rikezero.mtgapi_kotlin_sdk.domain.repository.MtgApiRepository
 import com.rikezero.mtgapi_kotlin_sdk.domain.result.MtgApiResult
 import com.rikezero.mtgapi_kotlin_sdk.domain.usecase.base.MtgApiUseCase
 
+/**
+ * Use case for retrieving all Magic: The Gathering card supertypes (e.g., Basic, Legendary, Snow).
+ *
+ * Delegates to [MtgApiRepository.getSupertypes]. No input parameters are required.
+ */
 class GetSuperTypesUseCase(
     private val mtgApiRepository: MtgApiRepository
 ): MtgApiUseCase<Unit, SuperTypesModel>() {
+
+    /**
+     * Executes the use case by fetching all available card supertypes.
+     *
+     * @param params Unused — pass [Unit].
+     * @return [MtgApiResult] wrapping a [SuperTypesModel] on success, or a failure on error.
+     */
     override suspend fun execute(params: Unit): MtgApiResult<SuperTypesModel> {
         return mtgApiRepository.getSupertypes()
     }

--- a/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/usecase/GetTypesUseCase.kt
+++ b/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/domain/usecase/GetTypesUseCase.kt
@@ -5,9 +5,21 @@ import com.rikezero.mtgapi_kotlin_sdk.domain.repository.MtgApiRepository
 import com.rikezero.mtgapi_kotlin_sdk.domain.result.MtgApiResult
 import com.rikezero.mtgapi_kotlin_sdk.domain.usecase.base.MtgApiUseCase
 
+/**
+ * Use case for retrieving all Magic: The Gathering card types (e.g., Creature, Instant, Sorcery).
+ *
+ * Delegates to [MtgApiRepository.getTypes]. No input parameters are required.
+ */
 class GetTypesUseCase(
     private val mtgApiRepository: MtgApiRepository
 ): MtgApiUseCase<Unit, TypesModel>() {
+
+    /**
+     * Executes the use case by fetching all available card types.
+     *
+     * @param params Unused — pass [Unit].
+     * @return [MtgApiResult] wrapping a [TypesModel] on success, or a failure on error.
+     */
     override suspend fun execute(params: Unit): MtgApiResult<TypesModel> {
         return mtgApiRepository.getTypes()
     }

--- a/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/networking/MtgApiNetworking.kt
+++ b/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/networking/MtgApiNetworking.kt
@@ -12,28 +12,88 @@ import com.rikezero.mtgapi_kotlin_sdk.networking.response.types.SuperTypesRespon
 import com.rikezero.mtgapi_kotlin_sdk.networking.response.types.TypesResponse
 import kotlin.jvm.Throws
 
+/**
+ * Low-level networking contract for the MTG API.
+ *
+ * Each method maps to a specific MTG API endpoint and returns the raw response type wrapped
+ * in [MtgApiResponse]. All methods may throw [MtgApiError] on network or server failures.
+ * Callers in the domain layer should not use this interface directly — use the repository instead.
+ */
 interface MtgApiNetworking {
+
+    /**
+     * Fetches a list of cards matching the provided query parameters.
+     *
+     * @param queries Key-value map of query parameters (e.g., name, set, rarity).
+     * @return [MtgApiResponse] wrapping a nullable [CardListResponse].
+     * @throws MtgApiError if the network request fails or the server returns an error.
+     */
     @Throws(MtgApiError::class)
     suspend fun getCards(queries: HashMap<String,String>): MtgApiResponse<CardListResponse?>
 
+    /**
+     * Fetches a single card matching the provided identifier.
+     *
+     * @param id The card's MTG API ID or Multiverse ID.
+     * @return [MtgApiResponse] wrapping a nullable [CardResponse].
+     * @throws MtgApiError if the network request fails or the server returns an error.
+     */
     @Throws(MtgApiError::class)
     suspend fun getCardById(id: String): MtgApiResponse<CardResponse?>
 
+    /**
+     * Fetches a list of sets matching the provided query parameters.
+     *
+     * @param queries Key-value map of query parameters (e.g., name, block).
+     * @return [MtgApiResponse] wrapping a nullable [CardSetListResponse].
+     * @throws MtgApiError if the network request fails or the server returns an error.
+     */
     @Throws(MtgApiError::class)
     suspend fun getSets(queries: HashMap<String, String>): MtgApiResponse<CardSetListResponse?>
 
+    /**
+     * Fetches a single set matching the provided set code.
+     *
+     * @param code The set code (e.g., "KTK" for Khans of Tarkir).
+     * @return [MtgApiResponse] wrapping a nullable [CardSetResponse].
+     * @throws MtgApiError if the network request fails or the server returns an error.
+     */
     @Throws(MtgApiError::class)
     suspend fun getSetByCode(code: String): MtgApiResponse<CardSetResponse?>
 
+    /**
+     * Fetches all available card types from the MTG API.
+     *
+     * @return [MtgApiResponse] wrapping a nullable [TypesResponse].
+     * @throws MtgApiError if the network request fails or the server returns an error.
+     */
     @Throws(MtgApiError::class)
     suspend fun getTypes(): MtgApiResponse<TypesResponse?>
 
+    /**
+     * Fetches all available card subtypes from the MTG API.
+     *
+     * @return [MtgApiResponse] wrapping a nullable [SubtypesResponse].
+     * @throws MtgApiError if the network request fails or the server returns an error.
+     */
     @Throws(MtgApiError::class)
     suspend fun getSubtypes(): MtgApiResponse<SubtypesResponse?>
 
+    /**
+     * Fetches all available card supertypes from the MTG API.
+     *
+     * @return [MtgApiResponse] wrapping a nullable [SuperTypesResponse].
+     * @throws MtgApiError if the network request fails or the server returns an error.
+     */
     @Throws(MtgApiError::class)
     suspend fun getSupertypes(): MtgApiResponse<SuperTypesResponse?>
 
+    /**
+     * Fetches all supported game formats from the MTG API.
+     *
+     * @return [MtgApiResponse] wrapping a nullable [FormatsResponse].
+     * @throws MtgApiError if the network request fails or the server returns an error.
+     */
     @Throws(MtgApiError::class)
     suspend fun getFormats(): MtgApiResponse<FormatsResponse?>
 }

--- a/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/networking/engine/MtgApiNetworkEngine.kt
+++ b/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/networking/engine/MtgApiNetworkEngine.kt
@@ -6,7 +6,28 @@ import com.rikezero.mtgapi_kotlin_sdk.networking.response.MtgApiResponse
 import kotlin.jvm.Throws
 import kotlin.reflect.KClass
 
+/**
+ * Core HTTP execution engine for the MTG API SDK.
+ *
+ * Responsible for making the actual network call and returning a raw [MtgApiResponse].
+ * Implementations wrap a concrete HTTP client (e.g., Retrofit + OkHttp) and translate
+ * HTTP errors into [MtgApiError] exceptions. This interface should not be called directly
+ * by application code — use the repository or use-case layer instead.
+ */
 interface MtgApiNetworkEngine {
+
+    /**
+     * Executes an HTTP GET request and returns the deserialized response.
+     *
+     * @param T The expected response body type; must be a non-null type.
+     * @param url The full URL of the resource to fetch.
+     * @param headers Additional HTTP headers to include in the request.
+     * @param queryParams URL query parameters to append to the request URL.
+     * @param responseClass The [KClass] of the expected response type, used for deserialization.
+     * @param deserializer An optional custom Gson [JsonDeserializer] for [T]; `null` uses the default deserializer.
+     * @return [MtgApiResponse] wrapping the deserialized response body, which may be `null` if the server returns no body.
+     * @throws MtgApiError if the network request fails or the server returns an error HTTP status.
+     */
     @Throws(MtgApiError::class)
     suspend fun <T : Any> get(
         url: String,

--- a/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/networking/networkadapter/MtgApiNetworkAdapter.kt
+++ b/src/main/kotlin/com/rikezero/mtgapi_kotlin_sdk/networking/networkadapter/MtgApiNetworkAdapter.kt
@@ -4,7 +4,27 @@ import com.google.gson.JsonDeserializer
 import com.rikezero.mtgapi_kotlin_sdk.networking.response.MtgApiResponse
 import kotlin.reflect.KClass
 
+/**
+ * Adapter layer between the high-level [com.rikezero.mtgapi_kotlin_sdk.networking.MtgApiNetworking]
+ * interface and the underlying [com.rikezero.mtgapi_kotlin_sdk.networking.engine.MtgApiNetworkEngine].
+ *
+ * Implementations are responsible for constructing the final request (merging headers, query
+ * parameters, base URL, etc.) and delegating execution to the engine. This abstraction makes
+ * the networking layer independently testable and swappable.
+ */
 interface MtgApiNetworkAdapter {
+
+    /**
+     * Performs an HTTP GET request and deserializes the response body.
+     *
+     * @param T The expected response body type; must be a non-null type.
+     * @param url The full URL of the resource to fetch.
+     * @param headers Additional HTTP headers to include in the request.
+     * @param queryParams URL query parameters to append to the request URL.
+     * @param responseClass The [KClass] of the expected response type, used for deserialization.
+     * @param deserializer An optional custom Gson [JsonDeserializer] for [T]; `null` uses the default deserializer.
+     * @return [MtgApiResponse] wrapping the deserialized response body, which may be `null` if the server returns no body.
+     */
     suspend fun <T : Any> get(
         url: String,
         headers: Map<String, String> = emptyMap(),


### PR DESCRIPTION
Closes #32

## Summary
- KDoc added to all 8 use case classes + invoke/execute methods
- GetCardsUseCase.GetCardsParams: all 27 @param tags verified/completed
- MtgApiRepository: all methods documented with @param + @return
- All 10 domain models: class-level KDoc
- MtgApiResult extension functions: onSuccess, onFailure, map, mapToNotNull documented
- MtgApiFailure sealed class + all subtypes: KDoc with when-each-occurs explanation
- MtgApiNetworking, MtgApiNetworkAdapter, MtgApiNetworkEngine: interface + method KDoc
- startMtgApiLibrary(): existing KDoc retained
- context/kits/cavekit-kdoc.md: SDD spec R1-R6

## Test plan
- [ ] Run `./gradlew dokkaHtml` — completes without undocumented-symbol warnings
- [ ] All listed public classes have class-level KDoc in generated output
- [ ] No logic changes — diff is comments only

🤖 Generated with [Claude Code](https://claude.com/claude-code)